### PR TITLE
make it build

### DIFF
--- a/HiggsSet.cabal
+++ b/HiggsSet.cabal
@@ -69,11 +69,12 @@ Library
   Build-depends:       base >= 4.2 && < 6
                      , vector     
                      , TrieMap    >= 4.0.1
-                     , containers 
+                     , containers >= 0.4.2.0
                      , mtl        
                      , deepseq    
                      , bytestring  
                      , text
+                     , th-expand-syns >= 0.3.0.2
 
   
   -- Packages needed in order to build this package.


### PR DESCRIPTION
We need instances that are new in containers==0.4.2.0 but since it breaks
th-expand-syns<0.3.0.2, a dependency of TrieMap, we need to specify that
version constraint despite not using it directly ourselves.
